### PR TITLE
Fix nonce verify

### DIFF
--- a/lib/create-nonce.ts
+++ b/lib/create-nonce.ts
@@ -7,7 +7,7 @@ export function createNonce(txHashHex: string, blindingFactor: bigint): string {
   // Padding to complete 2 fields
   const nonceFields = ByteVector.fromHex(txHashHex).padRight(0, 62).toFieldArray();
   const hash = poseidon3([...nonceFields, blindingFactor]);
-  return ByteVector.fromBigInt(hash).toBase64Url();
+  return ByteVector.fromBigInt(hash).padLeft(0, 32).toBase64Url();
 }
 
 export function createNonceV2(address: Address, contractNonce: bigint, blindingFactor: bigint): [Hex, string] {

--- a/lib/create-nonce.ts
+++ b/lib/create-nonce.ts
@@ -25,5 +25,6 @@ export function createNonceV2(address: Address, contractNonce: bigint, blindingF
   const senderHash = keccak256(encoded);
   const nonceFields = ByteVector.fromHex(senderHash).padRight(0, 62).toFieldArray();
   const hash = poseidon3([...nonceFields, blindingFactor]);
-  return [senderHash, ByteVector.fromBigInt(hash).toBase64Url()];
+  const nonceBytes = ByteVector.fromBigInt(hash).padLeft(0, 32);
+  return [senderHash, nonceBytes.toBase64Url()];
 }

--- a/test/verify-nonce-test.circom
+++ b/test/verify-nonce-test.circom
@@ -1,0 +1,6 @@
+pragma circom 2.2.0;
+
+include "../utils/verify-nonce.circom";
+
+
+component main = VerifyNonce();

--- a/tooling/cli.ts
+++ b/tooling/cli.ts
@@ -1,9 +1,9 @@
 import { config } from "dotenv";
-import { getAddress, type Hex } from "viem";
+import { getAddress } from "viem";
 import yargs from "yargs";
 
 import { DEFAULT_PTAU_SIZE } from "../lib/constants.js";
-import { createNonceV2 } from "../lib/create-nonce.js";
+import { createNonceV2 } from "../lib/index.js";
 import { allCmd } from "./all.js";
 import { callVerifierCmd } from "./call-verifier.js";
 import { compileCmd } from "./compile.js";
@@ -18,6 +18,7 @@ import { digestCommand } from "./lib/digest.js";
 import { env } from "./lib/env.js";
 import { prepareZkeyCmd } from "./prepare-zkey.js";
 import { prove } from "./prove.js";
+import { runCmd } from "./run-cmd.js";
 import { verificationKeyCmd } from "./verification-key.js";
 import { verifyCmd } from "./verify.js";
 import { witnessCommand } from "./witness.js";
@@ -168,7 +169,16 @@ const args = yargs(process.argv.slice(2))
     "Performs all neded tasks to export verifier and prepared zkey",
     FILE_ARG_DEF,
     async (argv) => allCmd(argv.file),
-  ).command(
+  )
+  .command(
+    "run <file>",
+    "Generates inputs, wasm and witness for a circuit",
+    FILE_ARG_DEF,
+    async (argv) => {
+      await runCmd(argv.file);
+    },
+  )
+  .command(
     "create-nonce <address> <nonce>",
     "Creates a nonce for a given address and nonce",
     {

--- a/tooling/generate-input.ts
+++ b/tooling/generate-input.ts
@@ -9,6 +9,7 @@ import { cmd, ROOT_DIR } from "./lib/cmd.js";
 import { env } from "./lib/env.js";
 import { FrozenFireSha2Input } from "./lib/frozen-fire-sha2-input.js";
 import { PoseidonTest } from "./lib/poseidon-test-input.js";
+import { VerifyNonceTestInput } from "./verify-nonce-test-input.js";
 
 type InputGenerator = (jwt: string, key: string, salt: Hex, txHash: string, blinding: bigint) => CircuitInput;
 const INPUT_GENERATORS: Record<string, InputGenerator> = {
@@ -17,6 +18,7 @@ const INPUT_GENERATORS: Record<string, InputGenerator> = {
   "poseidon-test": () => new PoseidonTest(),
   "blinding-factor": (jwt, key, salt, txHash: string, blinding: bigint) =>
     new BlindingFactorInputTest(jwt, key, salt, txHash, blinding),
+  "verify-nonce-test": (jwt, key, salt, txHash, blinding) => new VerifyNonceTestInput(jwt, key, salt, txHash, blinding),
 };
 
 export async function inputCommand(filePath: string) {

--- a/tooling/lib/cmd.ts
+++ b/tooling/lib/cmd.ts
@@ -15,7 +15,7 @@ export async function cmd(strCmd: string): Promise<void> {
     const spawned = spawn(first, rest, { stdio: "inherit", cwd: ROOT_DIR });
     spawned.on("close", () => resolve());
     spawned.on("error", () => reject());
-    spawned.on("exit", () => resolve());
+    spawned.on("exit", (code) => code == 0 ? resolve() : reject(new Error(`cmd \`${strCmd}\` failed. exit code: ${code}`)));
     spawned.on("disconnect", () => reject());
   });
 }

--- a/tooling/run-cmd.ts
+++ b/tooling/run-cmd.ts
@@ -1,0 +1,9 @@
+import { compileCmd } from "./compile.js";
+import { inputCommand } from "./generate-input.js";
+import { witnessCommand } from "./witness.js";
+
+export async function runCmd(circuit: string) {
+  await inputCommand(circuit);
+  await compileCmd(circuit);
+  await witnessCommand(circuit);
+}

--- a/tooling/verify-nonce-test-input.ts
+++ b/tooling/verify-nonce-test-input.ts
@@ -1,0 +1,22 @@
+import { type CircuitSignals } from "snarkjs";
+
+import { ByteVector, type CircuitInput } from "../lib/index.js";
+import { env } from "./lib/env.js";
+
+export class VerifyNonceTestInput implements CircuitInput {
+  private base64Url: string;
+
+  constructor(_rawJWT: string, _jwkModulus: string, _salt: string, _txHash: string, _blinding: bigint) {
+    this.base64Url = "ALhc1WnmWtGsPDhHTia98aYPchLftHWm1qbjNBoR__I=";
+  }
+
+  toObject(): CircuitSignals {
+    return {
+      b64UrlNonce: ByteVector.fromAsciiString(this.base64Url).toCircomByteArray(),
+      blindingFactor: env("BLINDING_FACTOR"),
+      txHash: ByteVector.fromHex("0xdf6f6a92220f473b9f2f25d75029a2f33e4a0dfeeafdfed9e4f498737ab2f37d")
+        .toFieldArray()
+        .map((f) => f.toString()),
+    };
+  }
+}


### PR DESCRIPTION
# Description

This stream of work started because verification was throwing "false negatives". That means, it was failing to verify proofs that look correct.

After some analysis we found out that the problem was how the txHash was being encode inside the nonce. Hashes that fit in less than 32 bytes were being padded with zeros at the right instead of at the left. The fix, then, was on that encoding.

# Changes

- Created script to easily, compile, generate inputs and generate witness for a circuit.
- Created test circuit for specific nonce verification
- Fixed nonce building applying the right padding.