### PR TITLE
Audit/contract audit changes

### DIFF
--- a/lib/create-nonce.ts
+++ b/lib/create-nonce.ts
@@ -10,11 +10,24 @@ export function createNonce(contentHex: string, blindingFactor: bigint): string 
   return ByteVector.fromBigInt(hash).padLeft(0, 32).toBase64Url();
 }
 
-export function createNonceV2(address: Address, contractNonce: bigint, blindingFactor: bigint, timestampLimit: bigint): [Hex, string] {
+export function createNonceV2(
+  senderAddress: Address,
+  targetAddres: Address,
+  passkeyHash: Hex,
+  contractNonce: bigint,
+  blindingFactor: bigint,
+  timestampLimit: bigint,
+): [Hex, string] {
   const encoded = encodeAbiParameters(
     [
       {
         type: "address",
+      },
+      {
+        type: "address",
+      },
+      {
+        type: "bytes32",
       },
       {
         type: "uint256",
@@ -23,7 +36,7 @@ export function createNonceV2(address: Address, contractNonce: bigint, blindingF
         type: "uint256",
       },
     ],
-    [address, contractNonce, timestampLimit],
+    [senderAddress, targetAddres, passkeyHash, contractNonce, timestampLimit],
   );
   const senderHash = keccak256(encoded);
   const nonce = createNonce(senderHash, blindingFactor);

--- a/tooling/cli.ts
+++ b/tooling/cli.ts
@@ -1,5 +1,5 @@
 import { config } from "dotenv";
-import { getAddress } from "viem";
+import { getAddress, type Hex, pad } from "viem";
 import yargs from "yargs";
 
 import { DEFAULT_PTAU_SIZE } from "../lib/constants.js";
@@ -196,13 +196,23 @@ const args = yargs(process.argv.slice(2))
     },
   )
   .command(
-    "create-nonce <address> <nonce>",
+    "create-nonce <sender> <target> <passkeyHash> <nonce>",
     "Creates a nonce for a given address and nonce",
     {
-      address: {
+      sender: {
         type: "string",
         demandOption: true,
-        description: "Address to create nonce for",
+        description: "Address of the sender of the tx",
+      },
+      target: {
+        type: "string",
+        demandOption: true,
+        description: "Address of the account to recover",
+      },
+      passkeyHash: {
+        type: "string",
+        demandOption: true,
+        description: "hash of new passkey",
       },
       nonce: {
         type: "string",
@@ -212,7 +222,9 @@ const args = yargs(process.argv.slice(2))
     },
     async (argv) => {
       const nonce = createNonceV2(
-        getAddress(argv.address),
+        getAddress(argv.sender),
+        getAddress(argv.target),
+        pad(argv.passkeyHash as Hex),
         BigInt(argv.nonce),
         BigInt(env("BLINDING_FACTOR")),
         BigInt(env("TIMESTAMP_LIMIT")),


### PR DESCRIPTION
As part of the changes made for the associated contracts audit we incorporated the hash of the new passkey and the target address to be recovered into the jwt nonce. These are the changes on the lib side to make that easier.