### PR TITLE
N-02 Missing or Misleading Documentation

### DIFF
--- a/jwt-tx-validation.circom
+++ b/jwt-tx-validation.circom
@@ -34,7 +34,7 @@ include "./utils/verify-nonce.circom";
 /// @input nonceKeyStartIndex Index for "nonce":" substring inside the payload
 /// @input nonceLength Actual length for nonce string.
 /// @input expectedNonce Value expected for nonce.
-///        Even when this circuit works with any 44 charecter base64url nonce, it's
+///        Even when this circuit works with any 44 character base64url nonce, it's
 ///        meant to be used wit a nonce calculated as `Poseidon3(sender_hash[0..31], sender_hash.subarray[31..32], blinding_factor)`
 ///        where sender_hash is calculated as `keccak256(abi.encode(auxAddress, targetAddress, newPasskeyHash, recoverNonce, timeLimit))`
 /// @input issKeyStartIndex Index for '"iss":' substring in payload

--- a/jwt-tx-validation.circom
+++ b/jwt-tx-validation.circom
@@ -19,7 +19,8 @@ include "./utils/verify-nonce.circom";
 ///      5. Computing public key hash for external reference
 /// @param n RSA chunk size in bits (n < 127 for field arithmetic)
 /// @param k Number of RSA chunks (n*k > 2048 for RSA-2048)
-/// @param maxMessageLength Maximum JWT string length (must be multiple of 64 for SHA256)
+/// @param maxMessageLength Maximum raw JWT string length (This is header.payload,
+///        where both are base64url encoded) (must be multiple of 64 for SHA256)
 /// @param maxB64PayloadLength Maximum Base64 payload length (must be multiple of 4)
 /// @param maxNonceLength
 /// @param maxIssLength
@@ -33,6 +34,9 @@ include "./utils/verify-nonce.circom";
 /// @input nonceKeyStartIndex Index for "nonce":" substring inside the payload
 /// @input nonceLength Actual length for nonce string.
 /// @input expectedNonce Value expected for nonce.
+///        Even when this circuit works with any 44 charecter base64url nonce, it's
+///        meant to be used wit a nonce calculated as `Poseidon3(sender_hash[0..31], sender_hash.subarray[31..32], blinding_factor)`
+///        where sender_hash is calculated as `keccak256(abi.encode(auxAddress, recoverNonce, timeLimit))`
 /// @input issKeyStartIndex Index for '"iss":' substring in payload
 template JwtTxValidation(
   n,

--- a/jwt-tx-validation.circom
+++ b/jwt-tx-validation.circom
@@ -36,7 +36,7 @@ include "./utils/verify-nonce.circom";
 /// @input expectedNonce Value expected for nonce.
 ///        Even when this circuit works with any 44 charecter base64url nonce, it's
 ///        meant to be used wit a nonce calculated as `Poseidon3(sender_hash[0..31], sender_hash.subarray[31..32], blinding_factor)`
-///        where sender_hash is calculated as `keccak256(abi.encode(auxAddress, recoverNonce, timeLimit))`
+///        where sender_hash is calculated as `keccak256(abi.encode(auxAddress, targetAddress, newPasskeyHash, recoverNonce, timeLimit))`
 /// @input issKeyStartIndex Index for '"iss":' substring in payload
 template JwtTxValidation(
   n,

--- a/lib/byte-vector.ts
+++ b/lib/byte-vector.ts
@@ -73,6 +73,11 @@ export class ByteVector {
     return this.vec.flatMap((byte) => this.byteTo8digits(byte));
   }
 
+  toBnChunks(chunkSizeBytes: number): bigint[] {
+    return intoChunks(this.vec, chunkSizeBytes)
+      .map((chunk) => new ByteVector(chunk).toBigInt());
+  }
+
   toFieldArray(): bigint[] {
     return intoChunks(this.vec, FIELD_BYTES)
       .map((chunk) => new ByteVector(chunk).reverse())

--- a/lib/create-nonce.ts
+++ b/lib/create-nonce.ts
@@ -13,7 +13,7 @@ export function createNonce(contentHex: string, blindingFactor: bigint): string 
 
 export function createNonceV2(
   senderAddress: Address,
-  targetAddres: Address,
+  targetAddress: Address,
   passkeyHash: Hex,
   contractNonce: bigint,
   blindingFactor: bigint,
@@ -37,7 +37,7 @@ export function createNonceV2(
         type: "uint256",
       },
     ],
-    [senderAddress, targetAddres, passkeyHash, contractNonce, timestampLimit],
+    [senderAddress, targetAddress, passkeyHash, contractNonce, timestampLimit],
   );
   const senderHash = keccak256(encoded);
   const nonce = createNonce(senderHash, blindingFactor);

--- a/lib/create-nonce.ts
+++ b/lib/create-nonce.ts
@@ -2,19 +2,33 @@ import { poseidon3 } from "poseidon-lite";
 import { type Address, encodeAbiParameters, keccak256 } from "viem";
 
 import { ByteVector, type Hex } from "./byte-vector.js";
+import { FIELD_BYTES } from "./constants.js";
 
 export function createNonce(contentHex: string, blindingFactor: bigint): string {
   // Padding to complete 2 fields
-  const nonceFields = ByteVector.fromHex(contentHex).padRight(0, 62).toFieldArray();
+  const nonceFields = ByteVector.fromHex(contentHex).toBnChunks(FIELD_BYTES);
   const hash = poseidon3([...nonceFields, blindingFactor]);
   return ByteVector.fromBigInt(hash).padLeft(0, 32).toBase64Url();
 }
 
-export function createNonceV2(address: Address, contractNonce: bigint, blindingFactor: bigint, timestampLimit: bigint): [Hex, string] {
+export function createNonceV2(
+  senderAddress: Address,
+  targetAddres: Address,
+  passkeyHash: Hex,
+  contractNonce: bigint,
+  blindingFactor: bigint,
+  timestampLimit: bigint,
+): [Hex, string] {
   const encoded = encodeAbiParameters(
     [
       {
         type: "address",
+      },
+      {
+        type: "address",
+      },
+      {
+        type: "bytes32",
       },
       {
         type: "uint256",
@@ -23,7 +37,7 @@ export function createNonceV2(address: Address, contractNonce: bigint, blindingF
         type: "uint256",
       },
     ],
-    [address, contractNonce, timestampLimit],
+    [senderAddress, targetAddres, passkeyHash, contractNonce, timestampLimit],
   );
   const senderHash = keccak256(encoded);
   const nonce = createNonce(senderHash, blindingFactor);

--- a/lib/jwt-tx-validation-input.ts
+++ b/lib/jwt-tx-validation-input.ts
@@ -1,6 +1,6 @@
 import type { Hex } from "./byte-vector.js";
 import { CircomBigInt } from "./circom-big-int.js";
-import { AUD_MAX_LENGTH, ISS_MAX_LENGTH, MAX_B64_NONCE_LENGTH, MAX_MSG_LENGTH } from "./constants.js";
+import { AUD_MAX_LENGTH, FIELD_BYTES, ISS_MAX_LENGTH, MAX_B64_NONCE_LENGTH, MAX_MSG_LENGTH } from "./constants.js";
 import { ByteVector, OidcDigest } from "./index.js";
 import { JWT } from "./jwt.js";
 import type { CircuitInput } from "./types.js";
@@ -70,7 +70,7 @@ export class JwtTxValidationInputs implements CircuitInput {
   }
 
   private serializeNonceContentHash(): string[] {
-    return ByteVector.fromHex(this.rawNonceContentHash).toFieldArray().map((n) => n.toString());
+    return ByteVector.fromHex(this.rawNonceContentHash).toBnChunks(FIELD_BYTES).map((n) => n.toString());
   }
 
   private oidcDigest(): string {

--- a/tooling/cli.ts
+++ b/tooling/cli.ts
@@ -25,6 +25,7 @@ import { verifierTestCmd } from "./verifier-test.js";
 import { verifyCmd } from "./verify.js";
 import { witnessCommand } from "./witness.js";
 import { DEFAULT_PTAU, zkeyCommand } from "./zkey.js";
+import { runTestCmd } from "./run-test-cmd.js";
 
 config();
 
@@ -185,6 +186,14 @@ const args = yargs(process.argv.slice(2))
     FILE_ARG_DEF,
     async (argv) => {
       await runCmd(argv.file);
+    },
+  )
+  .command(
+    "run-test <file>",
+    "Generates inputs, wasm and witness for a test circuit",
+    FILE_ARG_DEF,
+    async (argv) => {
+      await runTestCmd(argv.file);
     },
   )
   .command(

--- a/tooling/cli.ts
+++ b/tooling/cli.ts
@@ -1,5 +1,5 @@
 import { config } from "dotenv";
-import { getAddress } from "viem";
+import { getAddress, type Hex, pad } from "viem";
 import yargs from "yargs";
 
 import { DEFAULT_PTAU_SIZE } from "../lib/constants.js";
@@ -205,13 +205,23 @@ const args = yargs(process.argv.slice(2))
     },
   )
   .command(
-    "create-nonce <address> <nonce>",
+    "create-nonce <sender> <target> <passkeyHash> <nonce>",
     "Creates a nonce for a given address and nonce",
     {
-      address: {
+      sender: {
         type: "string",
         demandOption: true,
-        description: "Address to create nonce for",
+        description: "Address of the sender of the tx",
+      },
+      target: {
+        type: "string",
+        demandOption: true,
+        description: "Address of the account to recover",
+      },
+      passkeyHash: {
+        type: "string",
+        demandOption: true,
+        description: "hash of new passkey",
       },
       nonce: {
         type: "string",
@@ -221,7 +231,9 @@ const args = yargs(process.argv.slice(2))
     },
     async (argv) => {
       const nonce = createNonceV2(
-        getAddress(argv.address),
+        getAddress(argv.sender),
+        getAddress(argv.target),
+        pad(argv.passkeyHash as Hex),
         BigInt(argv.nonce),
         BigInt(env("BLINDING_FACTOR")),
         BigInt(env("TIMESTAMP_LIMIT")),

--- a/tooling/run-test-cmd.ts
+++ b/tooling/run-test-cmd.ts
@@ -1,0 +1,16 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { compileCmd } from "./compile.js";
+import { cmd, ROOT_DIR } from "./lib/cmd.js";
+import { witnessCommand } from "./witness.js";
+
+export async function runTestCmd(circuitPath: string) {
+  const circomFileData = path.parse(circuitPath);
+  const inputDestinationPath = path.join(ROOT_DIR, "inputs", `${circomFileData.name}.input.json`);
+  const inputFileData = path.parse(inputDestinationPath);
+  writeFileSync(inputDestinationPath, Buffer.from("{}", "utf8"));
+  await cmd(`mkdir -p ${inputFileData.dir}`);
+  await compileCmd(circuitPath);
+  await witnessCommand(circuitPath);
+}

--- a/unit-tests/count-chat-occurrences-up-to.test.circom
+++ b/unit-tests/count-chat-occurrences-up-to.test.circom
@@ -1,0 +1,26 @@
+pragma circom 2.2.0;
+
+include "../utils/array.circom";
+
+
+template Main () {
+  signal test01 <== CountCharOccurrencesUpTo(4)([1,1,0,1], 4, 1);
+  test01 === 3;
+
+  signal test02 <== CountCharOccurrencesUpTo(4)([1,1,0,1], 1, 1);
+  test02 === 1;
+
+  signal test03 <== CountCharOccurrencesUpTo(4)([1,1,0,1], 4, 2);
+  test03 === 0;
+
+  signal test04 <== CountCharOccurrencesUpTo(4)([1,1,0,1], 4, 0);
+  test04 === 1;
+
+  signal test05 <== CountCharOccurrencesUpTo(4)([1,1,1,1], 2, 1);
+  test05 === 2;
+
+  signal test06 <== CountCharOccurrencesUpTo(4)([1,1,1,1], 0, 1);
+  test06 === 0;
+}
+
+component main = Main();

--- a/utils/array.circom
+++ b/utils/array.circom
@@ -39,3 +39,35 @@ template SelectSubArrayBase64(maxArrayLen, maxSubArrayLen) {
         out[i] <== gts[i].out * shifter.out[i] + (1 - gts[i].out) * 65;
     }
 }
+
+
+/// @title CountCharOccurrencesUpTo
+/// @notice Counts the number of occurrences of a specified character in an array up to a certain position
+/// @dev This template iterates through the input array and counts how many times the specified character appears in
+///      the first "upTo" elements.
+/// @input in[maxLength] The input array in which to count occurrences of the character
+/// @input upTo Max index used to count occurrences
+/// @input char The character to count within the input array
+/// @output count The number of times the specified character appears in the input array
+template CountCharOccurrencesUpTo(maxLength) {
+    signal input in[maxLength];
+    signal input upTo;
+    signal input char;
+    signal output count;
+
+    signal match[maxLength];
+    signal inRange[maxLength];
+    signal counter[maxLength];
+
+    match[0] <== IsEqual()([in[0], char]);
+    inRange[0] <== LessThan(log2Ceil(maxLength))([0, upTo]);
+    counter[0] <== match[0] * inRange[0];
+
+    for (var i = 1; i < maxLength; i++) {
+        match[i] <== IsEqual()([in[i], char]);
+        inRange[i] <== LessThan(log2Ceil(maxLength))([i, upTo]);
+        counter[i] <== counter[i-1] + match[i] * inRange[i];
+    }
+
+    count <== counter[maxLength-1];
+}

--- a/utils/bytes-to-field.circom
+++ b/utils/bytes-to-field.circom
@@ -2,6 +2,12 @@ pragma circom 2.2.0;
 
 include "@zk-email/circuits/utils/array.circom";
 
+/// @title BytesToField
+/// @notice Transform an array of bytes into a single field. The bytes are interpreted using little endian format.
+/// @dev This template assumes that every element of the input array is between 0 and 255.
+/// @dev The result might overflow if the input interpreted in little endian is bigger than a field.
+/// @param n the size of the array of bytes.
+/// @input inputs[n] List of bytes to be transformed into a field. The code assumes each element is a valid byte (0 <= inputs[i] <= 255).
 template BytesToField(n) {
   assert(n <= 32);
 
@@ -10,14 +16,17 @@ template BytesToField(n) {
   signal members[n];
   signal output out;
 
+  // First revert bytes.
   for (var i = 0; i < n; i++) {
     revert[n - i - 1] <== inputs[i];
   }
 
+  // Then multiply each number for the right factor.
   for (var i = 0; i < n; i++) {
     var shifts = i * 8;
     members[i] <== (1 << shifts) * revert[i];
   }
 
+  // Last, add each component to get the final value.
   out <== CalculateTotal(n)(members);
 }

--- a/utils/bytes.circom
+++ b/utils/bytes.circom
@@ -5,6 +5,7 @@
 pragma circom 2.1.6;
 
 include "circomlib/circuits/comparators.circom";
+include "@zk-email/circuits/utils/array.circom";
 
 /// @title FindRealMessageLength
 /// @notice Finds the length of the real message in a padded array by locating the first occurrence of 128
@@ -47,29 +48,4 @@ template FindRealMessageLength(maxLength) {
 
     // Constraint to ensure 128 was really found
     found[maxLength] === 1;
-}
-
-/// @title CountCharOccurrences
-/// @notice Counts the number of occurrences of a specified character in an array
-/// @dev This template iterates through the input array and counts how many times the specified character appears.
-/// @input in[maxLength] The input array in which to count occurrences of the character
-/// @input char The character to count within the input array
-/// @output count The number of times the specified character appears in the input array
-template CountCharOccurrences(maxLength) {
-    signal input in[maxLength];
-    signal input char;
-    signal output count;
-
-    signal match[maxLength];
-    signal counter[maxLength];
-
-    match[0] <== IsEqual()([in[0], char]);
-    counter[0] <== match[0];
-
-    for (var i = 1; i < maxLength; i++) {
-        match[i] <== IsEqual()([in[i], char]);
-        counter[i] <== counter[i-1] + match[i];
-    }
-
-    count <== counter[maxLength-1];
 }

--- a/utils/constants.circom
+++ b/utils/constants.circom
@@ -10,11 +10,6 @@ function JWT_KID_KEY_LENGTH() {
     return 6;
 }
 
-// KID is 20 bytes long
-function JWT_KID_LENGTH() {
-    return 40;
-}
-
 function AZP_KEY_LENGTH() {
     // len("azp":)
     return 6;

--- a/utils/fields.circom
+++ b/utils/fields.circom
@@ -10,6 +10,8 @@ include "./constants.circom";
 
 /// @title ExtractNonce
 /// @notice Extracts and validates nonce from nonce field
+/// @dev maxNonceLength length has to be lower or equal maxPayloadLength
+/// @dev nonceKeyStartIndex and nonceKeyStartIndex + nonceLength have to be in correct range
 /// @param maxNonceLength Maximum length of JWT payload
 /// @param maxNonceLength Maximum length of nonce string
 /// @input payload[maxNonceLength] JWT payload bytes
@@ -33,6 +35,8 @@ template ExtractNonce(maxPayloadLength, maxNonceLength) {
 
     // Extract nonce
     signal nonceStartIndex <== nonceKeyStartIndex + nonceKeyLength + 1;
+
+    // `RevealSubstring` asserts nonceStartIndex and nonceStartIndex + nonceLength are in valid range.
     nonce <== RevealSubstring(maxPayloadLength, maxNonceLength, 0)(payload, nonceStartIndex, nonceLength);
 }
 
@@ -40,6 +44,8 @@ template ExtractNonce(maxPayloadLength, maxNonceLength) {
 
 /// @title ExtractIssuer
 /// @notice Extracts and validates the 'iss' (Issuer) from JWT payload
+/// @dev maxNonceLength length has to be lower or equal maxPayloadLength
+/// @dev issKeyStartIndex and issKeyStartIndex + issLength have to be in correct range
 /// @param maxPayloadLength Maximum length of JWT payload
 /// @param maxIssLength Maximum length of issuer value in bytes
 /// @input payload[maxPayloadLength] JWT payload bytes
@@ -63,11 +69,15 @@ template ExtractIssuer(maxPayloadLength, maxIssLength) {
 
     // Reveal the iss in the payload
     signal issStartIndex <== issKeyStartIndex + issKeyLength + 1;
+
+    // `RevealSubstring` asserts issStartIndex and issStartIndex + issLength are in valid range.
     iss <== RevealSubstring(maxPayloadLength, maxIssLength, 0)(payload, issStartIndex, issLength);
 }
 
 /// @title ExtractAud
 /// @notice Extracts and validates the 'aud' (Audience) from JWT payload
+/// @dev maxNonceLength length has to be lower or equal maxPayloadLength
+/// @dev audKeyStartIndex and audKeyStartIndex + audLength have to be in correct range
 /// @param maxPayloadLength Maximum length of JWT payload
 /// @param maxAudLength Maximum length of aud value in bytes
 /// @input payload[maxPayloadLength] JWT payload bytes
@@ -91,12 +101,16 @@ template ExtractAud(maxPayloadLength, maxAudLength) {
 
     // Reveal the aud in the payload
     signal audStartIndex <== audKeyStartIndex + audKeyLength + 1;
+
+    // `RevealSubstring` asserts audStartIndex and audStartIndex + audLength are in valid range.
     aud <== RevealSubstring(maxPayloadLength, maxAudLength, 0)(payload, audStartIndex, audLength);
 }
 
 
 /// @title ExtractSub
 /// @notice Extracts and validates the 'sub' (Subject) from JWT payload
+/// @dev maxNonceLength length has to be lower or equal maxPayloadLength
+/// @dev audKeyStartIndex and audKeyStartIndex + audLength have to be in correct range
 /// @param maxPayloadLength Maximum length of JWT payload
 /// @param maxSubLength Maximum length of sub value in bytes
 /// @input payload[maxPayloadLength] JWT payload bytes
@@ -120,5 +134,7 @@ template ExtractSub(maxPayloadLength, maxSubLength) {
 
     // Reveal the sub in the payload
     signal subStartIndex <== subKeyStartIndex + subKeyLength + 1;
+
+    // `RevealSubstring` asserts subStartIndex and subStartIndex + subLength are in valid range.
     sub <== RevealSubstring(maxPayloadLength, maxSubLength, 0)(payload, subStartIndex, subLength);
 }

--- a/utils/jwt-verify.circom
+++ b/utils/jwt-verify.circom
@@ -13,6 +13,9 @@ include "@zk-email/circuits/lib/base64.circom";
 include "./bytes.circom";
 include "./array.circom";
 
+function ASCII_DOT() {
+  return 46;
+}
 
 /// @title JwtVerify
 /// @notice Verifies JWT signatures and extracts payload
@@ -80,12 +83,13 @@ template JwtVerify (
   signal period <== ItemAtIndex(maxMessageLength)(message, periodIndex);
   period === 46;
 
-  // Assert that period is unique
-  signal periodCount <== CountCharOccurrences(maxMessageLength)(message, 46);
-  periodCount === 1;
-
   // Find the real message length
   signal realMessageLength <== FindRealMessageLength(maxMessageLength)(message);
+
+  // Assert that period is unique
+  signal periodCount <== CountCharOccurrencesUpTo(maxMessageLength)(message, realMessageLength, ASCII_DOT());
+  periodCount === 1;
+
   signal b64HeaderLength <== periodIndex;
   signal b64PayloadLength <== realMessageLength - b64HeaderLength - 1;
   signal b64Payload[maxB64PayloadLength] <== SelectSubArrayBase64(maxMessageLength, maxB64PayloadLength)(message, b64HeaderLength + 1, b64PayloadLength);

--- a/utils/verify-nonce.circom
+++ b/utils/verify-nonce.circom
@@ -27,7 +27,7 @@ function MAX_BYTES_FIELD() {
 ///      2. Decide base64.
 ///      3. Calculate expected value (Poseidon(sender_hash || blinding_factor))
 ///      4. Ensures decoded nonce matches calculated hash
-///      The sender hash is calculated as keccak256(abi.encode(auxAddress, recoverNonce, timeLimit))
+///      The sender hash is calculated as keccak256(abi.encode(auxAddress, targetAddress, newPasskeyHash, recoverNonce, timeLimit))
 /// @input b64UrlNonce[44] the nonce encoded as base64url.
 /// @input blindingFactor Factor used to prevent google to identify user's transactions.
 /// @input txHash[2] Hash of the current transaction. The tx hash is 32 bytes long, this why its encoded in the following way:

--- a/utils/verify-nonce.circom
+++ b/utils/verify-nonce.circom
@@ -30,7 +30,7 @@ function MAX_BYTES_FIELD() {
 ///      The sender hash is calculated as keccak256(abi.encode(auxAddress, targetAddress, newPasskeyHash, recoverNonce, timeLimit))
 /// @input b64UrlNonce[44] the nonce encoded as base64url.
 /// @input blindingFactor Factor used to prevent google to identify user's transactions.
-/// @input txHash[2] Hash of the current transaction. The tx hash is 32 bytes long, this why its encoded in the following way:
+/// @input txHash[2] Hash of the current transaction. The tx hash is 32 bytes long, which is why it is encoded in the following way:
 ///        - txhash[0] contains the first 31 bytes of the txHash starting from the left interpreted as a single field.
 ///        - txhash[1] it's the last byte of the txHash starting from the left.
 template VerifyNonce() {

--- a/utils/verify-nonce.circom
+++ b/utils/verify-nonce.circom
@@ -19,17 +19,20 @@ function MAX_BYTES_FIELD() {
 }
 
 /// @title VerifyNonce
-/// @notice Verify content of nonce. Interpret nonce as base64url encoded blob. Check that matches Poseidon(tx_hash || blinding_factor)
+/// @notice Verify content of nonce. Interpret nonce as base64url encoded blob. Check that matches Poseidon(sender_hash || blinding_factor)
 /// @dev This template ensures the content of the nonce is the expected one.
 ///      Our nonce are always 44 characters long. That's why the length of the nonce is not a parameter.
 ///      It works by:
 ///      1. Converting base64url to base64.
 ///      2. Decide base64.
-///      3. Calculate expected value (Poseidon(tx_hash || blinding_factor))
+///      3. Calculate expected value (Poseidon(sender_hash || blinding_factor))
 ///      4. Ensures decoded nonce matches calculated hash
+///      The sender hash is calculated as keccak256(abi.encode(auxAddress, recoverNonce, timeLimit))
 /// @input b64UrlNonce[44] the nonce encoded as base64url.
 /// @input blindingFactor Factor used to prevent google to identify user's transactions.
-/// @input txHash[2] Hash of the current transaction. It's encoded as 2 Fields because it's 32 bytes long (each Field is 31)
+/// @input txHash[2] Hash of the current transaction. The tx hash is 32 bytes long, this why its encoded in the following way:
+///        - txhash[0] contains the first 31 bytes of the txHash starting from the left interpreted as a single field.
+///        - txhash[1] it's the last byte of the txHash starting from the left.
 template VerifyNonce() {
   var maxNonceB64Length = MAX_NONCE_BASE64_LENGTH();
   signal input b64UrlNonce[maxNonceB64Length];

--- a/utils/verify-oidc-digest.circom
+++ b/utils/verify-oidc-digest.circom
@@ -30,13 +30,16 @@ template VerifyOidcDigest(
   var issFieldLength = computeIntChunkLength(maxIssLength);
   var audFieldLength = computeIntChunkLength(maxAudLength);
   var subFieldLength = computeIntChunkLength(maxSubLength);
+
+  // These values are spread across the rest of the components. That's
+  // Why we assert the precise value.
   assert(issFieldLength == 1);
   assert(audFieldLength == 4);
   assert(subFieldLength == 1);
 
-  signal packedIss[computeIntChunkLength(issFieldLength)] <== PackBytes(maxIssLength)(iss);
-  signal packedAud[computeIntChunkLength(maxAudLength)] <== PackBytes(maxAudLength)(aud);
-  signal packedSub[computeIntChunkLength(maxSubLength)] <== PackBytes(maxSubLength)(sub);
+  signal packedIss[issFieldLength] <== PackBytes(maxIssLength)(iss);
+  signal packedAud[audFieldLength] <== PackBytes(maxAudLength)(aud);
+  signal packedSub[subFieldLength] <== PackBytes(maxSubLength)(sub);
 
   signal calculatedDigest <== Poseidon(7)([
     packedIss[0],

--- a/utils/verify-oidc-digest.circom
+++ b/utils/verify-oidc-digest.circom
@@ -15,7 +15,7 @@ include "circomlib/circuits/poseidon.circom";
 /// @input aud[maxAudLength] value for aud extracted from jwt.
 /// @input sub[maxSubLength] value for sub extracted from jwt.
 /// @input salt salt used to anonymize the result.
-/// @input expectedDigest Expected value for oidc_digest. This value is build by the user
+/// @input expectedDigest Expected value for oidc_digest. This value is built by the user
 ///        when the proof is generated, and then reconstructed by the smart contract when the proof
 ///        is verified.
 template VerifyOidcDigest(

--- a/utils/verify-oidc-digest.circom
+++ b/utils/verify-oidc-digest.circom
@@ -14,8 +14,10 @@ include "circomlib/circuits/poseidon.circom";
 /// @input iss[maxIssLength] value for iss extracted from jwt.
 /// @input aud[maxAudLength] value for aud extracted from jwt.
 /// @input sub[maxSubLength] value for sub extracted from jwt.
-/// @input salt salt used to anonymize the result. Provided by user.
-/// @input expectedDigest Expected value for oidc_digest. Provided by user.
+/// @input salt salt used to anonymize the result.
+/// @input expectedDigest Expected value for oidc_digest. This value is build by the user
+///        when the proof is generated, and then reconstructed by the smart contract when the proof
+///        is verified.
 template VerifyOidcDigest(
   maxIssLength,
   maxAudLength,


### PR DESCRIPTION
https://defender.openzeppelin.com/#/audit/ea40e4f9-ae7a-4170-8471-dd46491939b2/issues/N-07

Some of the comments were not addressed:

> In [line 49](https://github.com/Moonsong-Labs/zksync-social-login-circuit/blob/27cda6e74492fbad4aa3ca37ff5084ed391b534b/utils/jwt-verify.circom#L49) of jwt-verify.circom, consider documenting the fact that while the AssertZeroPadding template makes the assumption that [startIndex - 1 fits in ceil(log2(maxArrayLen)) bits](https://github.com/zkemail/zk-email-verify/blob/26d2632bb95d9419b0eebc71018c02313f7f41ce/packages/circuits/utils/array.circom#L148C78-L148C135) which is not respected if messageLength is 0, the [LessThan](https://github.com/zkemail/zk-email-verify/blob/26d2632bb95d9419b0eebc71018c02313f7f41ce/packages/circuits/utils/array.circom#L158-L160) would still work as expected.

We believe that the code is clear in the fact that we are following the assumptions made by `AssertZeroPadding`. We believe that adding comments regarding the internal behavior of the component might be confusing.

> Similarly, in the [fields.circom](https://github.com/Moonsong-Labs/zksync-social-login-circuit/blob/27cda6e74492fbad4aa3ca37ff5084ed391b534b/utils/fields.circom) file, the ExtractNonce, ExtractIssuer, ExtractAud, and ExtractSub templates use the RevealSubstring as a sub-template with the same argument formaxSubstringLength andsubstringLength (e.g. for nonce: [nonceKeyLength](https://github.com/Moonsong-Labs/zksync-social-login-circuit/blob/27cda6e74492fbad4aa3ca37ff5084ed391b534b/utils/fields.circom#L29)). This contradicts the assumption in SelectSubArray that length is [assumed to fit in ](https://github.com/zkemail/zk-email-verify/blob/26d2632bb95d9419b0eebc71018c02313f7f41ce/packages/circuits/utils/array.circom#L75C49-L75C97)[ceil(log2(maxArrayLen))](https://github.com/zkemail/zk-email-verify/blob/26d2632bb95d9419b0eebc71018c02313f7f41ce/packages/circuits/utils/array.circom#L75C49-L75C97)[ bits](https://github.com/zkemail/zk-email-verify/blob/26d2632bb95d9419b0eebc71018c02313f7f41ce/packages/circuits/utils/array.circom#L75C49-L75C97), as, for example, the nonce technically substringLength = 8 does not fit in ceil(log2(substringLength)) = 3 bits. Consider documenting that this is a known behavior, and that the [GreaterThan](https://github.com/zkemail/zk-email-verify/blob/26d2632bb95d9419b0eebc71018c02313f7f41ce/packages/circuits/utils/array.circom#L93-L95) still works as expected.

In this case we believe that we are following all the assumptions of `RevealSubstring`. 
In  the case of `SelectSubArray` (used inside `RevealSubstring`) the condition is that `issNonceLength` (which is always 8) has to fit in `ceil(log2(maxPayloadLength))`. `maxPayloadLength` in our case is `768`. So we are safe there. Also, `RevealSubstring` has an assertion that makes that condition always true: `assert(maxSubstringLength < maxLength);`.

As far as we understand, we are making a safe usage of `RevealSubstring`, and we are following their docs. We believe that adding more clarification there might be confusing.

> In [line 13](https://github.com/Moonsong-Labs/zksync-social-login-circuit/blob/27cda6e74492fbad4aa3ca37ff5084ed391b534b/utils/constants.circom#L13) of constants.circom, the KID is documented as being "20 bytes long", while the JWT_KID_LENGTH function returns 40. Consider clarifying the comment to indicate the reason for this behavior.

`JWT_KID_LENGTH` was not being used anywhere in the codebase. It was removed.